### PR TITLE
Agregando validacion al Money para mejorar el dominio de las\ entidades

### DIFF
--- a/src/cine_boletos_cli/domain/value_objects/money.py
+++ b/src/cine_boletos_cli/domain/value_objects/money.py
@@ -22,9 +22,10 @@ Este objeto no debe:
 - ejecutar lógica externa al dominio.
 """
 
+from decimal import Decimal
+
 from cine_boletos_cli.domain.exceptions.domain_errors import CurrencyMismatchError
 from cine_boletos_cli.shared.constants import DEFAULT_CURRENCY
-from decimal import Decimal
 
 
 class Money:
@@ -44,6 +45,7 @@ class Money:
     >>> Money("10.50", "USD")
     >>> Money(20, "EUR")
     """
+    VALID_TYPES = (str, int, Decimal)
 
     def __init__(self, amount, currency=DEFAULT_CURRENCY):
         """
@@ -57,6 +59,12 @@ class Money:
         currency : str
             Código de moneda.
         """
+
+        if not isinstance(amount, self.VALID_TYPES):
+            raise TypeError(
+                "amount debe ser str, int o Decimal."
+            )
+
 
         self.amount = Decimal(amount)
         self.currency = currency


### PR DESCRIPTION
Este pull request mejora el Value Object `Money` agregando validaciones
más estrictas y un manejo monetario más seguro dentro del dominio.

## Cambios realizados

- validación de tipos permitidos (`str`, `int`, `Decimal`)
- rechazo de tipos no soportados como `float`
- mejora de la seguridad en operaciones financieras
- preservación de precisión utilizando `Decimal`
- mantenimiento consistente de validación de moneda

## Motivación

El uso de `float` en valores monetarios puede introducir errores de
precisión en cálculos financieros.

Con este cambio se garantiza que representaciones inválidas sean
rechazadas desde el inicio y que el dominio mantenga un comportamiento
consistente y predecible.